### PR TITLE
add extractor module for platform-agnostic content extraction

### DIFF
--- a/backend/build.zig
+++ b/backend/build.zig
@@ -43,4 +43,27 @@ pub fn build(b: *std.Build) void {
 
     const run_step = b.step("run", "Run the server");
     run_step.dependOn(&run_cmd.step);
+
+    // test step
+    const test_step = b.step("test", "Run unit tests");
+
+    const test_files = [_][]const u8{
+        "src/search.zig",
+        "src/extractor.zig",
+    };
+
+    for (test_files) |file| {
+        const unit_tests = b.addTest(.{
+            .root_module = b.createModule(.{
+                .root_source_file = b.path(file),
+                .target = target,
+                .optimize = optimize,
+                .imports = &.{
+                    .{ .name = "zat", .module = zat.module("zat") },
+                },
+            }),
+        });
+        const run_tests = b.addRunArtifact(unit_tests);
+        test_step.dependOn(&run_tests.step);
+    }
 }

--- a/backend/src/extractor.zig
+++ b/backend/src/extractor.zig
@@ -1,0 +1,249 @@
+const std = @import("std");
+const mem = std.mem;
+const json = std.json;
+const Allocator = mem.Allocator;
+const zat = @import("zat");
+
+/// Detected platform from content.$type
+pub const Platform = enum {
+    leaflet,
+    pckt,
+    offprint,
+    unknown,
+
+    pub fn fromContentType(content_type: []const u8) Platform {
+        if (mem.startsWith(u8, content_type, "pub.leaflet.")) return .leaflet;
+        if (mem.startsWith(u8, content_type, "blog.pckt.")) return .pckt;
+        if (mem.startsWith(u8, content_type, "app.offprint.")) return .offprint;
+        return .unknown;
+    }
+
+    pub fn name(self: Platform) []const u8 {
+        return @tagName(self);
+    }
+};
+
+/// Extracted document data ready for indexing.
+/// All string fields are owned by this struct and must be freed via deinit().
+pub const ExtractedDocument = struct {
+    allocator: Allocator,
+    title: []const u8,
+    content: []u8,
+    created_at: ?[]const u8,
+    publication_uri: ?[]const u8,
+    tags: [][]const u8,
+    platform: Platform,
+    source_collection: []const u8,
+
+    pub fn deinit(self: *ExtractedDocument) void {
+        self.allocator.free(self.content);
+        self.allocator.free(self.tags);
+    }
+
+    /// Platform name as string (for DB storage)
+    pub fn platformName(self: ExtractedDocument) []const u8 {
+        return self.platform.name();
+    }
+};
+
+/// Block types that have a plaintext field
+const plaintext_blocks = std.StaticStringMap(void).initComptime(.{
+    .{ "pub.leaflet.blocks.text", {} },
+    .{ "pub.leaflet.blocks.header", {} },
+    .{ "pub.leaflet.blocks.blockquote", {} },
+    .{ "pub.leaflet.blocks.code", {} },
+});
+
+/// Detect platform from record's content.$type field
+pub fn detectPlatform(record: json.ObjectMap) Platform {
+    const content = record.get("content") orelse return .unknown;
+    if (content != .object) return .unknown;
+
+    const type_val = content.object.get("$type") orelse return .unknown;
+    if (type_val != .string) return .unknown;
+
+    return Platform.fromContentType(type_val.string);
+}
+
+/// Extract document content from a record.
+/// Caller owns the returned ExtractedDocument and must call deinit().
+pub fn extractDocument(
+    allocator: Allocator,
+    record: json.ObjectMap,
+    collection: []const u8,
+) !ExtractedDocument {
+    const record_val: json.Value = .{ .object = record };
+    const platform = detectPlatform(record);
+
+    // extract required fields
+    const title = zat.json.getString(record_val, "title") orelse return error.MissingTitle;
+
+    // extract optional fields
+    const created_at = zat.json.getString(record_val, "publishedAt") orelse
+        zat.json.getString(record_val, "createdAt");
+    const publication_uri = zat.json.getString(record_val, "publication") orelse
+        zat.json.getString(record_val, "site"); // site.standard uses "site"
+
+    // extract tags - allocate owned slice
+    const tags = try extractTags(allocator, record_val);
+    errdefer allocator.free(tags);
+
+    // extract content - try textContent first (standard.site), then parse blocks
+    const content = try extractContent(allocator, record_val);
+
+    return .{
+        .allocator = allocator,
+        .title = title,
+        .content = content,
+        .created_at = created_at,
+        .publication_uri = publication_uri,
+        .tags = tags,
+        .platform = platform,
+        .source_collection = collection,
+    };
+}
+
+fn extractTags(allocator: Allocator, record: json.Value) ![][]const u8 {
+    const tags_array = zat.json.getArray(record, "tags") orelse return &.{};
+
+    var count: usize = 0;
+    for (tags_array) |item| {
+        if (item == .string) count += 1;
+    }
+    if (count == 0) return &.{};
+
+    const tags = try allocator.alloc([]const u8, count);
+    var i: usize = 0;
+    for (tags_array) |item| {
+        if (item == .string) {
+            tags[i] = item.string;
+            i += 1;
+        }
+    }
+    return tags;
+}
+
+fn extractContent(allocator: Allocator, record: json.Value) ![]u8 {
+    var buf: std.ArrayList(u8) = .{};
+    errdefer buf.deinit(allocator);
+
+    // try textContent first (site.standard.document has this pre-flattened)
+    if (zat.json.getString(record, "textContent")) |text| {
+        try buf.appendSlice(allocator, text);
+        return try buf.toOwnedSlice(allocator);
+    }
+
+    // fall back to leaflet-style block parsing
+    if (zat.json.getString(record, "description")) |desc| {
+        try buf.appendSlice(allocator, desc);
+    }
+
+    if (zat.json.getArray(record, "pages")) |pages| {
+        for (pages) |page| {
+            if (page == .object) {
+                try extractPageContent(allocator, &buf, page.object);
+            }
+        }
+    }
+
+    if (buf.items.len == 0) return error.NoContent;
+    return try buf.toOwnedSlice(allocator);
+}
+
+fn extractPageContent(allocator: Allocator, buf: *std.ArrayList(u8), page: json.ObjectMap) Allocator.Error!void {
+    const blocks_val = page.get("blocks") orelse return;
+    if (blocks_val != .array) return;
+
+    for (blocks_val.array.items) |wrapper| {
+        if (wrapper != .object) continue;
+        const block_val = wrapper.object.get("block") orelse continue;
+        if (block_val != .object) continue;
+
+        try extractBlockText(allocator, buf, block_val.object);
+    }
+}
+
+fn extractBlockText(allocator: Allocator, buf: *std.ArrayList(u8), block: json.ObjectMap) Allocator.Error!void {
+    const type_val = block.get("$type") orelse return;
+    if (type_val != .string) return;
+    const block_type = type_val.string;
+
+    // blocks with plaintext field
+    if (plaintext_blocks.has(block_type)) {
+        try appendTextField(allocator, buf, block, "plaintext");
+    }
+    // button has text field
+    else if (mem.eql(u8, block_type, "pub.leaflet.blocks.button")) {
+        try appendTextField(allocator, buf, block, "text");
+    }
+    // list with nested children
+    else if (mem.eql(u8, block_type, "pub.leaflet.blocks.unorderedList")) {
+        try extractListContent(allocator, buf, block);
+    }
+}
+
+fn appendTextField(allocator: Allocator, buf: *std.ArrayList(u8), obj: json.ObjectMap, field: []const u8) Allocator.Error!void {
+    const val = obj.get(field) orelse return;
+    if (val != .string) return;
+    if (val.string.len == 0) return;
+
+    if (buf.items.len > 0) try buf.append(allocator, ' ');
+    try buf.appendSlice(allocator, val.string);
+}
+
+fn extractListContent(allocator: Allocator, buf: *std.ArrayList(u8), block: json.ObjectMap) Allocator.Error!void {
+    const children = block.get("children") orelse return;
+    if (children != .array) return;
+
+    for (children.array.items) |child| {
+        try extractListItem(allocator, buf, child);
+    }
+}
+
+fn extractListItem(allocator: Allocator, buf: *std.ArrayList(u8), item: json.Value) Allocator.Error!void {
+    if (item != .object) return;
+
+    // list item content
+    if (item.object.get("content")) |content| {
+        if (content == .object) {
+            try appendTextField(allocator, buf, content.object, "plaintext");
+        }
+    }
+
+    // nested children (recursive)
+    if (item.object.get("children")) |children| {
+        if (children == .array) {
+            for (children.array.items) |child| {
+                try extractListItem(allocator, buf, child);
+            }
+        }
+    }
+}
+
+// --- tests ---
+
+test "Platform.fromContentType: leaflet" {
+    try std.testing.expectEqual(Platform.leaflet, Platform.fromContentType("pub.leaflet.content"));
+    try std.testing.expectEqual(Platform.leaflet, Platform.fromContentType("pub.leaflet.blocks.text"));
+}
+
+test "Platform.fromContentType: pckt" {
+    try std.testing.expectEqual(Platform.pckt, Platform.fromContentType("blog.pckt.content"));
+    try std.testing.expectEqual(Platform.pckt, Platform.fromContentType("blog.pckt.blocks.whatever"));
+}
+
+test "Platform.fromContentType: offprint" {
+    try std.testing.expectEqual(Platform.offprint, Platform.fromContentType("app.offprint.content"));
+}
+
+test "Platform.fromContentType: unknown" {
+    try std.testing.expectEqual(Platform.unknown, Platform.fromContentType("something.else"));
+    try std.testing.expectEqual(Platform.unknown, Platform.fromContentType(""));
+}
+
+test "Platform.name" {
+    try std.testing.expectEqualStrings("leaflet", Platform.leaflet.name());
+    try std.testing.expectEqualStrings("pckt", Platform.pckt.name());
+    try std.testing.expectEqualStrings("offprint", Platform.offprint.name());
+    try std.testing.expectEqualStrings("unknown", Platform.unknown.name());
+}

--- a/backend/src/indexer.zig
+++ b/backend/src/indexer.zig
@@ -10,12 +10,14 @@ pub fn insertDocument(
     created_at: ?[]const u8,
     publication_uri: ?[]const u8,
     tags: []const []const u8,
+    platform: []const u8,
+    source_collection: []const u8,
 ) !void {
     const c = db.getClient() orelse return error.NotInitialized;
 
     try c.exec(
-        "INSERT OR REPLACE INTO documents (uri, did, rkey, title, content, created_at, publication_uri) VALUES (?, ?, ?, ?, ?, ?, ?)",
-        &.{ uri, did, rkey, title, content, created_at orelse "", publication_uri orelse "" },
+        "INSERT OR REPLACE INTO documents (uri, did, rkey, title, content, created_at, publication_uri, platform, source_collection) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        &.{ uri, did, rkey, title, content, created_at orelse "", publication_uri orelse "", platform, source_collection },
     );
 
     // update FTS index

--- a/backend/src/search.zig
+++ b/backend/src/search.zig
@@ -344,3 +344,51 @@ pub fn buildFtsQuery(alloc: Allocator, query: []const u8) ![]const u8 {
     buf[pos] = '*';
     return buf;
 }
+
+// --- tests ---
+
+test "buildFtsQuery: empty string" {
+    const result = try buildFtsQuery(std.testing.allocator, "");
+    try std.testing.expectEqualStrings("", result);
+}
+
+test "buildFtsQuery: whitespace only" {
+    const result = try buildFtsQuery(std.testing.allocator, "   ");
+    try std.testing.expectEqualStrings("", result);
+}
+
+test "buildFtsQuery: single word" {
+    const result = try buildFtsQuery(std.testing.allocator, "hello");
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("hello*", result);
+}
+
+test "buildFtsQuery: single word with whitespace" {
+    const result = try buildFtsQuery(std.testing.allocator, "  hello  ");
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("hello*", result);
+}
+
+test "buildFtsQuery: multiple words" {
+    const result = try buildFtsQuery(std.testing.allocator, "cat dog");
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("cat OR dog*", result);
+}
+
+test "buildFtsQuery: three words" {
+    const result = try buildFtsQuery(std.testing.allocator, "one two three");
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("one OR two OR three*", result);
+}
+
+test "buildFtsQuery: quoted phrase passthrough" {
+    const result = try buildFtsQuery(std.testing.allocator, "\"exact phrase\"");
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("\"exact phrase\"", result);
+}
+
+test "buildFtsQuery: dots as separators" {
+    const result = try buildFtsQuery(std.testing.allocator, "foo.bar");
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("foo OR bar*", result);
+}

--- a/backend/src/tap.zig
+++ b/backend/src/tap.zig
@@ -6,6 +6,7 @@ const Allocator = mem.Allocator;
 const websocket = @import("websocket");
 const zat = @import("zat");
 const indexer = @import("indexer.zig");
+const extractor = @import("extractor.zig");
 
 const DOCUMENT_COLLECTION = "pub.leaflet.document";
 const PUBLICATION_COLLECTION = "pub.leaflet.publication";
@@ -105,15 +106,6 @@ const TapRecord = struct {
     rkey: []const u8,
 };
 
-/// Leaflet document fields
-const LeafletDocument = struct {
-    title: []const u8,
-    publication: ?[]const u8 = null,
-    publishedAt: ?[]const u8 = null,
-    createdAt: ?[]const u8 = null,
-    description: ?[]const u8 = null,
-};
-
 /// Leaflet publication fields
 const LeafletPublication = struct {
     name: []const u8,
@@ -144,7 +136,7 @@ fn processMessage(allocator: Allocator, payload: []const u8) !void {
             const record_obj = zat.json.getObject(parsed.value, "record.record") orelse return;
 
             if (mem.eql(u8, rec.collection, DOCUMENT_COLLECTION)) {
-                processDocument(allocator, uri, did.raw, rec.rkey, record_obj) catch |err| {
+                processDocument(allocator, uri, did.raw, rec.rkey, record_obj, rec.collection) catch |err| {
                     std.debug.print("document processing error: {}\n", .{err});
                 };
             } else if (mem.eql(u8, rec.collection, PUBLICATION_COLLECTION)) {
@@ -165,127 +157,28 @@ fn processMessage(allocator: Allocator, payload: []const u8) !void {
     }
 }
 
-fn processDocument(allocator: Allocator, uri: []const u8, did: []const u8, rkey: []const u8, record: json.ObjectMap) !void {
-    const record_val: json.Value = .{ .object = record };
-
-    // extract known fields via struct
-    const doc = zat.json.extractAt(LeafletDocument, allocator, record_val, .{}) catch return;
-    const created_at = doc.publishedAt orelse doc.createdAt;
-
-    // extract tags array
-    var tags_list: std.ArrayList([]const u8) = .{};
-    defer tags_list.deinit(allocator);
-    if (zat.json.getArray(record_val, "tags")) |tags| {
-        for (tags) |tag_item| {
-            if (tag_item == .string) {
-                try tags_list.append(allocator, tag_item.string);
-            }
+fn processDocument(allocator: Allocator, uri: []const u8, did: []const u8, rkey: []const u8, record: json.ObjectMap, collection: []const u8) !void {
+    var doc = extractor.extractDocument(allocator, record, collection) catch |err| {
+        if (err != error.NoContent and err != error.MissingTitle) {
+            std.debug.print("extraction error for {s}: {}\n", .{ uri, err });
         }
-    }
+        return;
+    };
+    defer doc.deinit();
 
-    // extract plaintext from pages
-    var content_buf: std.ArrayList(u8) = .{};
-    defer content_buf.deinit(allocator);
-
-    if (doc.description) |desc| {
-        if (desc.len > 0) {
-            try content_buf.appendSlice(allocator, desc);
-        }
-    }
-
-    if (zat.json.getArray(record_val, "pages")) |pages| {
-        for (pages) |page| {
-            if (page == .object) {
-                try extractPlaintextFromPage(allocator, &content_buf, page.object);
-            }
-        }
-    }
-
-    if (content_buf.items.len == 0) return;
-
-    try indexer.insertDocument(uri, did, rkey, doc.title, content_buf.items, created_at, doc.publication, tags_list.items);
-    std.debug.print("indexed document: {s} ({} chars, {} tags)\n", .{ uri, content_buf.items.len, tags_list.items.len });
-}
-
-fn extractPlaintextFromPage(allocator: Allocator, buf: *std.ArrayList(u8), page: json.ObjectMap) !void {
-    // pages can be linearDocument or canvas
-    // linearDocument has blocks array
-    const blocks_val = page.get("blocks") orelse return;
-    if (blocks_val != .array) return;
-
-    for (blocks_val.array.items) |block_wrapper| {
-        if (block_wrapper != .object) continue;
-
-        // block wrapper has "block" field with actual content
-        const block_val = block_wrapper.object.get("block") orelse continue;
-        if (block_val != .object) continue;
-
-        try extractTextFromBlock(allocator, buf, block_val.object);
-    }
-}
-
-fn extractTextFromBlock(allocator: Allocator, buf: *std.ArrayList(u8), block: json.ObjectMap) Allocator.Error!void {
-    const type_val = block.get("$type") orelse return;
-    if (type_val != .string) return;
-
-    const block_type = type_val.string;
-
-    // blocks with plaintext field: text, header, blockquote, code
-    if (mem.eql(u8, block_type, "pub.leaflet.blocks.text") or
-        mem.eql(u8, block_type, "pub.leaflet.blocks.header") or
-        mem.eql(u8, block_type, "pub.leaflet.blocks.blockquote") or
-        mem.eql(u8, block_type, "pub.leaflet.blocks.code"))
-    {
-        if (block.get("plaintext")) |plaintext_val| {
-            if (plaintext_val == .string) {
-                if (buf.items.len > 0) {
-                    try buf.appendSlice(allocator, " ");
-                }
-                try buf.appendSlice(allocator, plaintext_val.string);
-            }
-        }
-    }
-    // button has text field
-    else if (mem.eql(u8, block_type, "pub.leaflet.blocks.button")) {
-        if (block.get("text")) |text_val| {
-            if (text_val == .string) {
-                if (buf.items.len > 0) {
-                    try buf.appendSlice(allocator, " ");
-                }
-                try buf.appendSlice(allocator, text_val.string);
-            }
-        }
-    }
-    // unorderedList has children array with nested content
-    else if (mem.eql(u8, block_type, "pub.leaflet.blocks.unorderedList")) {
-        if (block.get("children")) |children_val| {
-            if (children_val == .array) {
-                for (children_val.array.items) |child| {
-                    try extractListItemText(allocator, buf, child);
-                }
-            }
-        }
-    }
-}
-
-fn extractListItemText(allocator: Allocator, buf: *std.ArrayList(u8), item: json.Value) Allocator.Error!void {
-    if (item != .object) return;
-
-    // list item has content field which is a block
-    if (item.object.get("content")) |content_val| {
-        if (content_val == .object) {
-            try extractTextFromBlock(allocator, buf, content_val.object);
-        }
-    }
-
-    // nested children
-    if (item.object.get("children")) |children_val| {
-        if (children_val == .array) {
-            for (children_val.array.items) |child| {
-                try extractListItemText(allocator, buf, child);
-            }
-        }
-    }
+    try indexer.insertDocument(
+        uri,
+        did,
+        rkey,
+        doc.title,
+        doc.content,
+        doc.created_at,
+        doc.publication_uri,
+        doc.tags,
+        doc.platformName(),
+        doc.source_collection,
+    );
+    std.debug.print("indexed document: {s} [{s}] ({} chars, {} tags)\n", .{ uri, doc.platformName(), doc.content.len, doc.tags.len });
 }
 
 fn processPublication(allocator: Allocator, uri: []const u8, did: []const u8, rkey: []const u8, record: json.ObjectMap) !void {


### PR DESCRIPTION
## Summary
- New `extractor.zig` module with `extractDocument()` and `detectPlatform()`
- Uses `textContent` field for standard.site records (no block parsing needed)
- Falls back to leaflet block parsing for `pub.leaflet.*` records
- Detects platform from `content.$type` prefix (leaflet, pckt, offprint)
- Indexer now stores `platform` and `source_collection` columns
- Removed ~100 lines of inline extraction code from tap.zig

## Test plan
- [ ] Deploy and verify existing leaflet documents still index correctly
- [ ] Confirm platform='leaflet' is set for new documents
- [ ] Ready for PR3 to add site.standard.document subscription

🤖 Generated with [Claude Code](https://claude.com/claude-code)